### PR TITLE
Enhance homepage and add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ Open `index.html` in any modern web browser to view the homepage. No server is r
 
 * Edit `styles/main.css` to change colors, fonts and layout.
 * Add new JavaScript files inside the `scripts/` folder as needed.
+
+## Deployment
+
+This repository includes a GitHub Actions workflow that publishes the site using
+GitHub Pages. After enabling Pages in the repository settings, pushes to the
+`main` branch will automatically build and deploy `index.html` and related
+assets.

--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@
             </ul>
         </nav>
     </header>
+    <section class="hero">
+        <h2>مرحباً بك في مستقبل طب الأسنان</h2>
+        <p>استكشف أحدث التقنيات والحلول الرقمية لعيادتك.</p>
+        <a href="#intro" class="cta">ابدأ الآن</a>
+    </section>
     <main>
         <section id="intro">
             <h2>مقدمة</h2>
@@ -63,6 +68,8 @@
     <footer id="contact">
         <p>&copy; 2023 بوابة طب الأسنان الرقمي</p>
     </footer>
+
+    <button id="topBtn" class="top-btn hidden">&#8593;</button>
 
     <script src="scripts/main.js"></script>
 </body>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -18,3 +18,19 @@ programButtons.forEach(btn => {
     }
   });
 });
+
+// Scroll to top functionality
+const topBtn = document.getElementById('topBtn');
+if (topBtn) {
+  window.addEventListener('scroll', () => {
+    if (window.pageYOffset > 100) {
+      topBtn.classList.remove('hidden');
+    } else {
+      topBtn.classList.add('hidden');
+    }
+  });
+
+  topBtn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -12,6 +12,27 @@ header {
     padding: 1rem;
 }
 
+.hero {
+    background: linear-gradient(135deg, #005b9a, #0099cc);
+    color: white;
+    text-align: center;
+    padding: 4rem 1rem;
+}
+
+.hero .cta {
+    display: inline-block;
+    margin-top: 1rem;
+    background-color: #ffffff;
+    color: #005b9a;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    border-radius: 4px;
+}
+
+.hero .cta:hover {
+    background-color: #f2f2f2;
+}
+
 nav ul {
     list-style: none;
     padding: 0;
@@ -63,4 +84,20 @@ button:hover {
 
 .program-info {
     margin-top: 0.5rem;
+}
+
+.top-btn {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    border: none;
+    padding: 0.5rem 0.75rem;
+    border-radius: 50%;
+    background-color: #005b9a;
+    color: white;
+    cursor: pointer;
+}
+
+.top-btn:hover {
+    background-color: #003d66;
 }


### PR DESCRIPTION
## Summary
- add a hero section and scroll-to-top button
- style the new elements
- update site script with scroll-to-top logic
- document automatic deployment to GitHub Pages
- create a GitHub Actions workflow for Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9ece138832f82a76db8fa8d4506